### PR TITLE
fix: Add `output` to list of config options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Config options:
 - [`no_tty`](#no_tty)
 - [`extends`](#extends)
 - [`min_version`](#min_version)
+- [`output`](#output)
 - [`skip_output`](#skip_output)
 - [`source_dir`](#source_dir)
 - [`source_dir_local`](#source_dir_local)


### PR DESCRIPTION
#### :zap: Summary

Add a missing link to the already existing documentation for the `output` config option.

#### :ballot_box_with_check: Checklist

- [X] Check locally  (No code was changed, but rendering of README was verified)
- [X] ~Add tests~ (No code was changed)
- [X] Add documentation
